### PR TITLE
Update landing page to explain "open-source" delay

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@ customjs:
 				<div class="col-sm-4 feature">
 					<span class="fa-stack fa-2x"><i class="fa fa-circle fa-stack-2x cnm-color8"></i> <i class="fa fa-github fa-stack-1x fa-inverse"></i></span>
 					<h5><strong>Source Available &amp; Transparent</strong></h5>
-					<p>No hidden code, no malicious modules, no exploits, no small letters. Our code is <a href="https://github.com/coinomi/" target="_blank">publicly available</a> for anyone to review.</p>
+					<p>No hidden code, no malicious modules, no exploits, no small letters. Our code is <a href="https://github.com/coinomi/" target="_blank">publicly available</a> for anyone to review, with a <a href="https://github.com/bitcoin-dot-org/bitcoin.org/issues/1622#issuecomment-307114670" target="_blank">delay for security reasons</a>.</p>
 				</div>
 
 


### PR DESCRIPTION
Seems that source code is on a delay, meaning the source in the various app stores isn't the same as the source in GitHub. As a result, quite a few people have been concerned (e.g. https://github.com/Coinomi/coinomi-android/issues/204). This clarifies the stance on the landing page. Feel free to reject, but wanted to at least put this out there.

This is an attempt at addressing #204